### PR TITLE
upgrade to patched operator to fix capability issue

### DIFF
--- a/manifests/vault-operator.yaml
+++ b/manifests/vault-operator.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: vault-operator
-        image: quay.io/coreos/vault-operator:latest
+        image: quay.io/usermirror/vault:v1
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Change vault-operator image to add `IPC_LOCK` capability to vault executable.