### PR TITLE
Load template variables from ConfigMap

### DIFF
--- a/manifests/config.yaml
+++ b/manifests/config.yaml
@@ -3,5 +3,7 @@ kind: ConfigMap
 metadata:
   name: deploy-config
 data:
-  embed-config-api: ""
+  embed-config-api: |
+    sql_server_addr: "http://google.com:8989/po?useNotEvil"
+    racingMode: "False"
   prometheus: ""

--- a/manifests/config.yaml
+++ b/manifests/config.yaml
@@ -4,6 +4,5 @@ metadata:
   name: deploy-config
 data:
   embed-config-api: |
-    sql_server_addr: "http://google.com:8989/po?useNotEvil"
-    racingMode: "False"
+    sql_db_password: "changeme"
   prometheus: ""

--- a/scripts/configmap.sh
+++ b/scripts/configmap.sh
@@ -30,7 +30,7 @@ function print_configmap() {
 function print_first_configmap() {
 	local filename=${1}
 
-	${KCONVERT} -f ${filename} -o go-template='{{range $lk, $lv := .items}}{{range $k, $v := $lv.data}},"{{js $k}}":"{{js $v}}"{{end}}{{end}}'
+	${KCONVERT} -f ${filename} -o go-template='{{range $flk, $flv := .items}}{{range $lk, $lv := $flv.items}}{{range $k, $v := $lv.data}},"{{js $k}}":"{{js $v}}"{{end}}{{end}}{{end}}'
 }
 
 # Convert YAML formatted ConfigMap Value to temporary string:string ConfigMap for given file and key.

--- a/scripts/configmap.sh
+++ b/scripts/configmap.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Run kubectl configured to convert and not use API server.
+KCONVERT="kubectl --server 127.0.0.8 convert --local"
+
 # Reads the contents of a ConfigMap as string:string JSON map suitable for Terraform.
 function main() {
 	local filename=${1}
@@ -7,16 +10,48 @@ function main() {
 		echo "A filename containing a ConfigMap must be specified" >&2 && exit 1
 	fi
 
-	read_configmap ${filename}
+	local key=${2}
+	if [ -z ${key} ]; then
+		print_configmap ${filename} | close_json
+	else
+		read_configmap_value ${filename} ${key} | print_first_configmap - | close_json
+	fi
+
 }
 
 # Use kubectl to extract keys + values of ConfigMap.
-function read_configmap() {
+function print_configmap() {
 	local filename=${1}
-	local template=
 
-	local contents="$(kubectl --server 127.0.0.8 convert -f ${filename} -o go-template='{{range $k, $v := .data}}"{{$k}}":"{{$v}}",{{end}}ENDMAP' | grep ",ENDMAP" | sed -e "s/,ENDMAP//g")"
-	echo "{${contents}}"
+	${KCONVERT} -f ${filename} -o go-template='{{range $k, $v := .data}},"{{js $k}}":"{{js $v}}"{{end}}'
+}
+
+# Use kubectl to extract keys + values of first ConfigMap in list of them.
+function print_first_configmap() {
+	local filename=${1}
+
+	${KCONVERT} -f ${filename} -o go-template='{{range $lk, $lv := .items}}{{range $k, $v := $lv.data}},"{{js $k}}":"{{js $v}}"{{end}}{{end}}'
+}
+
+# Convert YAML formatted ConfigMap Value to temporary string:string ConfigMap for given file and key.
+function read_configmap_value() {
+	local filename=${1}
+	local key=${2}
+
+	cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: temp
+data:
+  _name: ${key}
+$(${KCONVERT} -f ${filename} -o go-template="{{range \$k, \$v := .data}}{{if eq \$k \"${key}\"}}{{\$v}}{{end}}{{end}}" | sed "s/^/  /g")
+EOF
+}
+
+# Places brackets around JSON body
+function close_json() {
+	echo "{$(cat)}" | sed 's/{,/{/g'
 }
 
 main "$@"

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "sql_db_password" {
   type        = "string"
   default     = "changeme"
 }
+
+variable "components" {
+  description = "List of components to be deployed"
+  type        = "list"
+  default     = ["prometheus", "embed-config-api"]
+}


### PR DESCRIPTION
- Created top level variable to define which components should be deployed
- Parse ConfigMap values as YAML document whose keys/values can be used in templates

TODO: support `_preset` global variables in Terraform (already supported by bash script)