### PR TITLE
Reapply manifests when templates/variables change

### DIFF
--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -8,6 +8,10 @@ provider "template" {
   version = "~> 1.0"
 }
 
+locals {
+  output_dirs = "${formatlist("%s/%s", var.render_dir, var.components)}"
+}
+
 // ConfigMap describing deployment configuration
 data "external" "config" {
   count = "${length(var.components)}"
@@ -24,7 +28,7 @@ resource "template_dir" "kube_manifests" {
   count = "${length(var.components)}"
 
   source_dir      = "${var.manifest_dir}/${element(var.components, count.index)}"
-  destination_dir = "${var.render_dir}/${element(var.components, count.index)}"
+  destination_dir = "${element(local.output_dirs, count.index)}"
 
   vars = "${merge(data.external.config.*.result[count.index], var.vars)}"
 }

--- a/modules/config/output.tf
+++ b/modules/config/output.tf
@@ -5,5 +5,5 @@ output "manifest_state" {
 
 output "dirs" {
   description = "Directories which were templated into"
-  value       = ["${template_dir.kube_manifests.*.destination_dir}"]
+  value       = "${local.output_dirs}"
 }

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -1,6 +1,20 @@
+// generate hash of files in directory
+data "external" "dir_hash" {
+  count = "${length(var.manifest_dirs)}"
+
+  program = [
+    "${path.module}/scripts/hash-dir.sh",
+    "${element(var.manifest_dirs, count.index)}",
+  ]
+}
+
 // objects created from Kubernetes manifests.
 resource "null_resource" "objects" {
   count = "${length(var.manifest_dirs)}"
+
+  triggers {
+    dir_hash = "${data.external.dir_hash.*.result.hash[count.index]}"
+  }
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/manifests.sh create ${element(var.manifest_dirs, count.index)}"

--- a/modules/kubernetes/scripts/hash-dir.sh
+++ b/modules/kubernetes/scripts/hash-dir.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Calculates a hash for the directory given as an argument and outputs it in a JSON object.
+function main() {
+	if [ ${#} -eq 0 ] || [ ${1} == "-h" ] || [ ${1} == "--help" ]; then
+		echo "${0}: Calculates hashes of directories"
+		echo
+		echo "Usage: ${0} <DIRECTORY>"
+		exit 1
+	fi
+
+	local path="${1}"
+	printf '{"hash":"%s"}\n' $(hash-dir ${path})
+}
+
+# Returns a SHA1 hash of the SHA1 hash of every file in the directory.
+function hash-dir() {
+	local dir=${1}
+
+	find ${dir} -maxdepth 1 -type f -exec sha1sum {} + | sort -z | sha1sum | cut -d" " -f1
+}
+
+main "$@"


### PR DESCRIPTION
Currently, if manifests or templates are updated after Help Users Vote has been deployed they need to be manually `kubectl apply`-ied. This will create issues in the futures of updating existing manifests.

This PR uses the change in hash of the generated manifests to determine when resources need to be reapplied and performs the update.