### PR TITLE
move kubeconfig templating to separate module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,16 @@ module "kubernetes" {
   source = "./modules/kubernetes"
 
   manifest_dir = "${var.render_dir}/manifests"
-  render_dir   = "${var.render_dir}/generated"
+  kubeconfig   = "${module.kubeconfig.path}"
+
+  last_resource = "${module.cloud_sql.last_resource}"
+}
+
+// generate kubeconfig to authenticate with Kubernete API server
+module "kubeconfig" {
+  source = "./modules/kubeconfig"
+
+  render_dir = "${var.render_dir}"
 
   server             = "https://${google_container_cluster.huv_cluster.endpoint}"
   username           = "${google_container_cluster.huv_cluster.master_auth.0.username}"
@@ -69,8 +78,6 @@ module "kubernetes" {
   client_certificate = "${google_container_cluster.huv_cluster.master_auth.0.client_certificate}"
   client_key         = "${google_container_cluster.huv_cluster.master_auth.0.client_key}"
   ca_certificate     = "${google_container_cluster.huv_cluster.master_auth.0.cluster_ca_certificate}"
-
-  last_resource = "${module.cloud_sql.last_resource}"
 }
 
 // cloud_sql provides persistence backed by PostreSQL on Google Cloud.

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -1,0 +1,28 @@
+// kubeconfig generated using credentials provided to module.
+resource "local_file" "kubeconfig" {
+  filename = "${var.render_dir}/kubeconfig"
+
+  content = <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: huv-cluster
+  cluster:
+    api-version: v1
+    server: "${var.server}"
+    certificate-authority-data: "${var.ca_certificate}"
+users:
+- name: huv-admin
+  user:
+    username: "${var.username}"
+    password: "${var.password}"
+    client-certificate-data: "${var.client_certificate}"
+    client-key-data: "${var.client_key}"
+contexts:
+- name: huv
+  context:
+    cluster: huv-cluster
+    user: huv-admin
+current-context: huv
+EOF
+}

--- a/modules/kubeconfig/outputs.tf
+++ b/modules/kubeconfig/outputs.tf
@@ -1,0 +1,4 @@
+output "path" {
+  description = "Path where the kubeconfig was rendered"
+  value       = "${local_file.kubeconfig.filename}"
+}

--- a/modules/kubeconfig/variables.tf
+++ b/modules/kubeconfig/variables.tf
@@ -1,0 +1,40 @@
+variable "render_dir" {
+  description = "Directory where rendered rendered should be placed"
+  type        = "string"
+}
+
+variable "server" {
+  description = "Kubernetes API server URL (http/https)"
+  type        = "string"
+  default     = ""
+}
+
+variable "username" {
+  description = "Username used to authenticate with Kubernetes API server"
+  type        = "string"
+  default     = ""
+}
+
+variable "password" {
+  description = "Password used to authenticate with Kubernetes API server"
+  type        = "string"
+  default     = ""
+}
+
+variable "client_certificate" {
+  description = "Base64 encoded x509 Client certificate to authenticate with Kubernetes API server."
+  type        = "string"
+  default     = ""
+}
+
+variable "client_key" {
+  description = "Base64 encoded x509 Client key to authenticate with Kubernetes API server."
+  type        = "string"
+  default     = ""
+}
+
+variable "ca_certificate" {
+  description = "Base64 encoded x509 Certifiate Authority certificate to authenticate with Kubernetes API server."
+  type        = "string"
+  default     = ""
+}

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -4,7 +4,7 @@ resource "null_resource" "objects" {
     command = "${path.module}/scripts/manifests.sh create ${var.manifest_dir}"
 
     environment {
-      KUBECONFIG = "${local_file.kubeconfig.filename}"
+      KUBECONFIG = "${var.kubeconfig}"
       LAST       = "${var.last_resource}"
     }
   }
@@ -15,36 +15,7 @@ resource "null_resource" "objects" {
     command    = "${path.module}/scripts/manifests.sh destroy ${var.manifest_dir}"
 
     environment {
-      KUBECONFIG = "${local_file.kubeconfig.filename}"
+      KUBECONFIG = "${var.kubeconfig}"
     }
   }
-}
-
-// kubeconfig generated using credentials provided to module.
-resource "local_file" "kubeconfig" {
-  filename = "${var.render_dir}/kubeconfig"
-
-  content = <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- name: huv-cluster
-  cluster:
-    api-version: v1
-    server: "${var.server}"
-    certificate-authority-data: "${var.ca_certificate}"
-users:
-- name: huv-admin
-  user:
-    username: "${var.username}"
-    password: "${var.password}"
-    client-certificate-data: "${var.client_certificate}"
-    client-key-data: "${var.client_key}"
-contexts:
-- name: huv
-  context:
-    cluster: huv-cluster
-    user: huv-admin
-current-context: huv
-EOF
 }

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -3,45 +3,9 @@ variable "manifest_dir" {
   type        = "string"
 }
 
-variable "render_dir" {
-  description = "Directory where rendered manifests should be sent"
+variable "kubeconfig" {
+  description = "Path to kubeconfig used to authenticate with API server"
   type        = "string"
-}
-
-variable "server" {
-  description = "Kubernetes API server URL (http/https)"
-  type        = "string"
-  default     = ""
-}
-
-variable "username" {
-  description = "Username used to authenticate with Kubernetes API server"
-  type        = "string"
-  default     = ""
-}
-
-variable "password" {
-  description = "Password used to authenticate with Kubernetes API server"
-  type        = "string"
-  default     = ""
-}
-
-variable "client_certificate" {
-  description = "Base64 encoded x509 Client certificate to authenticate with Kubernetes API server."
-  type        = "string"
-  default     = ""
-}
-
-variable "client_key" {
-  description = "Base64 encoded x509 Client key to authenticate with Kubernetes API server."
-  type        = "string"
-  default     = ""
-}
-
-variable "ca_certificate" {
-  description = "Base64 encoded x509 Certifiate Authority certificate to authenticate with Kubernetes API server."
-  type        = "string"
-  default     = ""
 }
 
 variable "last_resource" {


### PR DESCRIPTION
Allows kubeconfig path to be specified instead of requiring one be generated.