### PR TITLE
Output directory per component

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,15 +53,15 @@ module "config" {
   components   = "${var.components}"
   config       = "${path.module}/manifests/config.yaml"
   manifest_dir = "${path.module}/manifests"
-  render_dir   = "${var.render_dir}"
+  render_dir   = "${var.render_dir}/manifests"
 }
 
 // kubernetes allows syncing manifests to the Kubernetes API server.
 module "kubernetes" {
   source = "./modules/kubernetes"
 
-  manifest_dir = "${var.render_dir}/manifests"
-  kubeconfig   = "${module.kubeconfig.path}"
+  manifest_dirs = "${module.config.dirs}"
+  kubeconfig    = "${module.kubeconfig.path}"
 
   last_resource = "${module.cloud_sql.last_resource}"
 }
@@ -84,7 +84,7 @@ module "kubeconfig" {
 module "cloud_sql" {
   source = "./modules/cloud_sql"
 
-  manifest_dir              = "${var.render_dir}/manifests"
+  manifest_dir              = "${var.render_dir}/manifests/embed-config-api"
   access_service_account_id = "${var.sql_service_account_id}"
   db_user_password          = "${var.sql_db_password}"
 }

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -24,7 +24,7 @@ resource "template_dir" "kube_manifests" {
   count = "${length(var.components)}"
 
   source_dir      = "${var.manifest_dir}/${element(var.components, count.index)}"
-  destination_dir = "${var.render_dir}/manifests"
+  destination_dir = "${var.render_dir}/${element(var.components, count.index)}"
 
   vars = "${data.external.config.*.result[count.index]}"
 }

--- a/modules/config/output.tf
+++ b/modules/config/output.tf
@@ -2,3 +2,8 @@ output "manifest_state" {
   description = "List of Terraform generated hashes for each template directory"
   value       = "${template_dir.kube_manifests.*.id}"
 }
+
+output "dirs" {
+  description = "Directories which were templated into"
+  value       = ["${template_dir.kube_manifests.*.destination_dir}"]
+}

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -1,7 +1,9 @@
 // objects created from Kubernetes manifests.
 resource "null_resource" "objects" {
+  count = "${length(var.manifest_dirs)}"
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/manifests.sh create ${var.manifest_dir}"
+    command = "${path.module}/scripts/manifests.sh create ${element(var.manifest_dirs, count.index)}"
 
     environment {
       KUBECONFIG = "${var.kubeconfig}"
@@ -12,7 +14,7 @@ resource "null_resource" "objects" {
   provisioner "local-exec" {
     when       = "destroy"
     on_failure = "continue"
-    command    = "${path.module}/scripts/manifests.sh destroy ${var.manifest_dir}"
+    command    = "${path.module}/scripts/manifests.sh destroy ${element(var.manifest_dirs, count.index)}"
 
     environment {
       KUBECONFIG = "${var.kubeconfig}"

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -1,6 +1,6 @@
-variable "manifest_dir" {
-  description = "Path to a directory containing manifests to be applied to the cluster"
-  type        = "string"
+variable "manifest_dirs" {
+  description = "Paths of directories containing manifests to be applied to the cluster"
+  type        = "list"
 }
 
 variable "kubeconfig" {


### PR DESCRIPTION
This PR:
- Maintains the directory structure as manifests are templated so that each component has its own directory
- Each created directory is `kubectl apply`-ed into the cluster
