### PR TITLE
Use config-api Terraform module for deploy

### DIFF
--- a/manifests/config.yaml
+++ b/manifests/config.yaml
@@ -3,6 +3,3 @@ kind: ConfigMap
 metadata:
   name: deploy-config
 data:
-  embed-config-api: |
-    sql_db_password: "changeme"
-  prometheus: ""

--- a/modules/cloudsql_db/main.tf
+++ b/modules/cloudsql_db/main.tf
@@ -11,8 +11,6 @@ resource "google_sql_user" "config-api" {
 resource "google_sql_database" "config-api" {
   name     = "${var.db_name}"
   instance = "${var.instance}"
-
-  depends_on = ["google_sql_database.config-api"]
 }
 
 // kubeconfig generated using credentials provided to module.

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -1,8 +1,6 @@
 // kubeconfig generated using credentials provided to module.
-resource "local_file" "kubeconfig" {
-  filename = "${var.render_dir}/kubeconfig"
-
-  content = <<EOF
+locals {
+  kubeconfig = <<EOF
 apiVersion: v1
 kind: Config
 clusters:
@@ -25,4 +23,11 @@ contexts:
     user: huv-admin
 current-context: huv
 EOF
+}
+
+// write kubeconfig to disk if render_dir is provided
+resource "local_file" "kubeconfig" {
+  filename = "${var.render_dir}/kubeconfig"
+
+  content = "${local.kubeconfig}"
 }

--- a/modules/kubeconfig/outputs.tf
+++ b/modules/kubeconfig/outputs.tf
@@ -2,3 +2,9 @@ output "path" {
   description = "Path where the kubeconfig was rendered"
   value       = "${local_file.kubeconfig.filename}"
 }
+
+output "kubeconfig" {
+  description = "Contents of the kubeconfig generated for the cluster"
+  value       = "${local.kubeconfig}"
+  sensitive   = true
+}

--- a/modules/kubeconfig/variables.tf
+++ b/modules/kubeconfig/variables.tf
@@ -1,6 +1,7 @@
 variable "render_dir" {
-  description = "Directory where rendered rendered should be placed"
+  description = "Directory where rendered kubeconfig should be placed. If empty, no file is rendered."
   type        = "string"
+  default     = ""
 }
 
 variable "server" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,20 @@
+output "sql_service_account_email" {
+  description = "Email of Google Service Account with access to connect to the database"
+  value       = "${module.cloudsql.sql_service_account_email}"
+}
+
+output "sql_connection_name" {
+  description = "Hostname provided by Cloud SQL to connect to a database instance"
+  value       = "${module.cloudsql.connection_name}"
+}
+
+output "sql_instance" {
+  description = "ID of the database instance within Cloud SQL."
+  value       = "${module.cloudsql.instance_id}"
+}
+
+output "kubeconfig" {
+  description = "Contents of the kubeconfig generated for the cluster"
+  value       = "${module.kubeconfig.kubeconfig}"
+  sensitive   = true
+}


### PR DESCRIPTION
Switches to using config-api Terraform module to deploy.

Configuration for the Cloud SQL instance and the Kubernetes cluster are passed to the module to allow it to create config-apis's database and create manifests in the cluster.