### PR TITLE
Require variable to destroy manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ export PATH := ./bin:$(PATH)
 
 deploy:
 	terraform apply -auto-approve
+	terraform apply -auto-approve
 
 destroy:
-	terraform destroy -auto-approve
+	terraform destroy -auto-approve -var 'do_destroy=true'
 
 check:
 	terraform init

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -28,7 +28,12 @@ resource "null_resource" "objects" {
   provisioner "local-exec" {
     when       = "destroy"
     on_failure = "continue"
-    command    = "${path.module}/scripts/manifests.sh destroy ${element(var.manifest_dirs, count.index)}"
+
+    command = <<EOF
+	if [ "${var.do_destroy}" == "1" ]; then
+		${path.module}/scripts/manifests.sh destroy ${element(var.manifest_dirs, count.index)}
+        fi
+EOF
 
     environment {
       KUBECONFIG = "${var.kubeconfig}"

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -13,3 +13,8 @@ variable "last_resource" {
   type        = "string"
   default     = ""
 }
+
+variable "do_destroy" {
+  description = "Actually destroy manifests, otherwise will skip"
+  default     = false
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -28,5 +28,6 @@ module "kubernetes" {
 
   manifest_dirs = "${module.config.dirs}"
   kubeconfig    = "${var.kubeconfig}"
+  do_destroy    = "${var.do_destroy}"
   last_resource = "${join(",", module.config.manifest_state)}"
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -38,3 +38,8 @@ variable "last_resource" {
   type        = "string"
   default     = ""
 }
+
+variable "do_destroy" {
+  description = "Actually destroy manifests, otherwise will skip"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -50,8 +50,7 @@ variable "sql_db_password" {
   default     = "changeme"
 }
 
-variable "components" {
-  description = "List of components to be deployed"
-  type        = "list"
-  default     = ["prometheus", "embed-config-api"]
+variable "do_destroy" {
+  description = "Actually destroy manifests, otherwise will skip"
+  default     = false
 }


### PR DESCRIPTION
Add variable that prevents destruction when the objects null_resource gets tainted. Destruction will only be performed when it has been explicitly set.