### PR TITLE
Always apply manifests

### DIFF
--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -13,7 +13,8 @@ resource "null_resource" "objects" {
   count = "${length(var.manifest_dirs)}"
 
   triggers {
-    dir_hash = "${data.external.dir_hash.*.result.hash[count.index]}"
+    timestamp = "${timestamp()}"
+    dir_hash  = "${data.external.dir_hash.*.result.hash[count.index]}"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
To ensure the cluster has the latest manifests always run `kubectl apply` even if no manifest changes has been detected.