### PR TITLE
Fix prometheus monitor selector

### DIFF
--- a/modules/prometheus/manifests/prometheus/prometheus-instance.yaml
+++ b/modules/prometheus/manifests/prometheus/prometheus-instance.yaml
@@ -6,7 +6,7 @@ spec:
   serviceAccountName: prometheus
   serviceMonitorSelector:
     matchLabels:
-      funk-component: ingress
+      um-component: prometheus
   resources:
     requests:
       memory: 400Mi


### PR DESCRIPTION
Correct label that's used for ServiceMonitors 